### PR TITLE
feat: introduce lisk sepolia

### DIFF
--- a/packages/contracts/hardhat.config.ts
+++ b/packages/contracts/hardhat.config.ts
@@ -42,10 +42,6 @@ export default {
       ...sharedNetworkConfig,
       url: `https://mainnet.infura.io/v3/${INFURA_KEY}`,
     },
-    goerli: {
-      ...sharedNetworkConfig,
-      url: `https://goerli.infura.io/v3/${INFURA_KEY}`,
-    },
     gnosis: {
       ...sharedNetworkConfig,
       url: "https://rpc.gnosischain.com",
@@ -58,6 +54,12 @@ export default {
       ...sharedNetworkConfig,
       url: `https://sepolia.infura.io/v3/${INFURA_KEY}`,
     },
+    "lisk-sepolia": {
+      ...sharedNetworkConfig,
+      chainId: 4202,
+      url: "https://rpc.sepolia-api.lisk.com",
+      gasPrice: 1000000000,
+    },
   },
   namedAccounts: {
     deployer: 0,
@@ -66,6 +68,24 @@ export default {
     timeout: 2000000,
   },
   etherscan: {
-    apiKey: ETHERSCAN_API_KEY,
+    apiKey: {
+      mainnet: ETHERSCAN_API_KEY,
+      sepolia: ETHERSCAN_API_KEY,
+      // Use "ETHERSCAN_API_KEY" as a placeholder, because Blockscout doesn't need a real API key, and Hardhat will complain if this property isn't set.
+      "lisk-sepolia": ETHERSCAN_API_KEY,
+    } as Record<string, string>,
+    customChains: [
+      {
+        network: "lisk-sepolia",
+        chainId: 4202,
+        urls: {
+          apiURL: "https://sepolia-blockscout.lisk.com/api",
+          browserURL: "https://sepolia-blockscout.lisk.com",
+        },
+      },
+    ],
+  },
+  sourcify: {
+    enabled: false,
   },
 };


### PR DESCRIPTION
## **Description:**

This PR adds support for the **Lisk Sepolia** testnet in Hardhat configuration. The newly introduced network allows deploying and verifying smart contracts on Lisk's Sepolia blockchain.

### Changes:
- Added `lisk-sepolia` network configuration to `hardhat.config.ts`.
- Included `lisk-sepolia` under the `etherscan.apiKey` configuration using a placeholder key.
- Extended `customChains` configuration to support contract verification for Lisk Sepolia.

### Deployment and Verification:
The following contracts were successfully deployed on **Lisk Sepolia**:
- 🚀 ExitERC20@1.2.0: Successfully verified at https://sepolia-blockscout.lisk.com/address/0x3ed380a282aDfA3460da28560ebEB2F6D967C9f5
- 🚀 ExitERC721@1.2.0: Successfully verified at https://sepolia-blockscout.lisk.com/address/0xE0eCE32Eb4BE4E9224dcec6a4FcB335c1fe05CDe
- 🚀 CirculatingSupplyERC20@1.2.0: Successfully verified at https://sepolia-blockscout.lisk.com/address/0x5Ed57C291a184cc244F5c9B5E9F11a8DD08BBd12
- 🚀 CirculatingSupplyERC721@1.2.0: Successfully verified at https://sepolia-blockscout.lisk.com/address/0xBD34D00dC0ae37C687F784A11FA6a0F2c5726Ba3


### References:
- Official Lisk documentation: [Deploying Smart Contracts with Hardhat](https://docs.lisk.com/building-on-lisk/deploying-smart-contract/with-Hardhat)
